### PR TITLE
fix: objectMapper 기본값 처리 방식과 무관하게 로그인 분기 처리

### DIFF
--- a/api/src/main/java/com/hearlers/gateway/config/JacksonConfig.java
+++ b/api/src/main/java/com/hearlers/gateway/config/JacksonConfig.java
@@ -12,7 +12,7 @@ public class JacksonConfig {
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
         return builder -> builder.postConfigurer(objectMapper -> {
-            objectMapper.setDefaultSetterInfo(JsonSetter.Value.forValueNulls(Nulls.AS_EMPTY));
+            objectMapper.setDefaultSetterInfo(JsonSetter.Value.forValueNulls(Nulls.DEFAULT));
         });
     }
 }

--- a/usecase/auth-usecase/src/main/java/com/hearlers/gateway/AuthUserService.java
+++ b/usecase/auth-usecase/src/main/java/com/hearlers/gateway/AuthUserService.java
@@ -52,7 +52,7 @@ public class AuthUserService implements AuthUserUseCase {
             return evaluateAndUpdateAuthority(authUser, uniqueId, providerPort);
         } catch (AuthUserNotFoundException e) {
             // 신규 로그인의 경우
-            if (userId == null) {
+            if (userId == null || userId == "") {
                 AuthUser newAuthUser = handleNewOAuthLogin(uniqueId, authChannel);
                 return evaluateAndUpdateAuthority(newAuthUser, uniqueId, providerPort);
             }


### PR DESCRIPTION
objectMapper에서 json 디코딩 될 때
설정에 따라 default value가 들어갈 수도 있는데
이에 무관하게 로그인 분기 처리하게 했습니다.