### PR TITLE
feat: 전역 rate-limiter 추가

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -32,4 +32,9 @@ dependencies {
 
     // Spring Security
     implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // resilience
+    implementation("io.github.resilience4j:resilience4j-ratelimiter:2.3.0")
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.3.0")
+
 }

--- a/api/src/main/java/com/hearlers/gateway/security/RateLimiterFilter.java
+++ b/api/src/main/java/com/hearlers/gateway/security/RateLimiterFilter.java
@@ -1,0 +1,41 @@
+package com.hearlers.gateway.security;
+
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Order(50)
+public class RateLimiterFilter extends OncePerRequestFilter {
+
+    private final RateLimiter rateLimiter;
+
+    public RateLimiterFilter(RateLimiterRegistry rateLimiterRegistry) {
+        this.rateLimiter = rateLimiterRegistry.rateLimiter("globalGatewayRateLimiter");
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @Nonnull HttpServletRequest request,
+            @Nonnull HttpServletResponse response,
+            @Nonnull FilterChain filterChain) throws ServletException, IOException {
+
+        if (rateLimiter.acquirePermission()) {
+            filterChain.doFilter(request, response);
+        } else {
+            response.setStatus(429);
+            response.getWriter().write("Too Many Requests");
+            response.getWriter().flush();
+        }
+    }
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -22,3 +22,10 @@ springdoc:
 grpc:
   targets:
     nest: ${GRPC_NEST_TARGET}
+
+resilience4j.ratelimiter:
+  instances:
+    globalGatewayRateLimiter:
+      limit-for-period: 100
+      limit-refresh-period: 1s
+      timeout-duration: 500ms


### PR DESCRIPTION
전역 rate limiter 추가했습니다
나중에 다중 인스턴스 환경 대응하려면 redis 등 공유 자원 기반 처리가 필요합니다만 일단 심플하게 넣었습니다

전 pr에 dependency 쪽 뜯어고쳐서 편의상 충돌 피하기 위해 연쇄 pr 합니당