### PR TITLE
fix: 임시로 호스트 네트워크로 도커 키도록

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -82,4 +82,4 @@ jobs:
             sudo docker stop $CONTAINER_ID && sudo docker rm $CONTAINER_ID
           fi
 
-          sudo docker run --env-file ./.env --platform linux/amd64 -d -p ${{ secrets.PORT }}:${{ secrets.PORT }} --name ${{ env.DOCKER_CONTAINER }} --network gateway --restart always ${{ env.DOCKER_IMAGE }}:latest
+          sudo docker run --env-file ./.env --platform linux/amd64 -d --name ${{ env.DOCKER_CONTAINER }} --network host --restart always ${{ env.DOCKER_IMAGE }}:latest


### PR DESCRIPTION
개발 서버에 k3s 띄우면서 도커랑 k3s끼리 브릿지 네트워크에서 충돌이 좀 나더라구요

일단 임시로 host 네트워크 쓰도록하구
각 repo helm기반 쿠버네티스 배포 형태로 바꾸면 될듯합니다